### PR TITLE
[PIZ7] Fix order price calculation

### DIFF
--- a/app/controllers/order.py
+++ b/app/controllers/order.py
@@ -12,7 +12,7 @@ class OrderController(BaseController):
 
     @staticmethod
     def calculate_order_price(size_price: float, ingredients: list):
-        price = sum(ingredient.price for ingredient in ingredients)
+        price = sum(ingredient.price for ingredient in ingredients) + size_price
         return round(price, 2)
 
     @classmethod


### PR DESCRIPTION
**Tasks:**

The total price calculation for the order did not include the price related to the size of the pizza. This value was included in the calculation function.

**File changed:**
- app/controllers/order.py